### PR TITLE
Tweak blurry half cards

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -12,7 +12,7 @@
   padding: 24px 110px;
   max-width: 1184px;
   margin: auto;
-  overflow-x: hidden;
+  /*overflow-x: hidden;*/
 }
 
 .wrapper {

--- a/src/App.css
+++ b/src/App.css
@@ -12,7 +12,6 @@
   padding: 24px 110px;
   max-width: 1184px;
   margin: auto;
-  /*overflow-x: hidden;*/
 }
 
 .wrapper {

--- a/src/components/feature-cards/FeatureCards.js
+++ b/src/components/feature-cards/FeatureCards.js
@@ -85,12 +85,12 @@ export const FeatureCards = ({ numberOfCards }) => {
 
     if (numberOfCards < 4) return false
 
-    if (numberOfCards == 6) {
-      if (i === activeItemIndex || i == activeItemIndex % features.length) return true
-      if (i === (activeItemIndex + 5) || i == (activeItemIndex + 5) % features.length) return true
+    if (numberOfCards === 6) {
+      if (i === activeItemIndex || i === activeItemIndex % features.length) return true
+      if (i === (activeItemIndex + 5) || i === (activeItemIndex + 5) % features.length) return true
     }
 
-    if (numberOfCards == 4) {
+    if (numberOfCards === 4) {
       const endingIndex = (activeItemIndex + numberOfCards) % features.length
       let startingIndex = endingIndex + numberOfCards - 1
       if (startingIndex >= features.length) {

--- a/src/components/feature-cards/FeatureCards.js
+++ b/src/components/feature-cards/FeatureCards.js
@@ -187,10 +187,10 @@ export const FeatureCards = ({ numberOfCards }) => {
 
 export default () => {
   const width = useWindowWidth()
-  const CARD_WIDTH = 310
+  const CARD_WIDTH = 300
   let numberOfCards = Math.floor(width / CARD_WIDTH)
 
-    if (width > 1900) {
+    if (width > 1800) {
       if (numberOfCards > 6) numberOfCards = 6
     } else {
       if (numberOfCards > 4) numberOfCards = 4

--- a/src/components/feature-cards/FeatureCards.js
+++ b/src/components/feature-cards/FeatureCards.js
@@ -82,14 +82,24 @@ export const FeatureCards = ({ numberOfCards }) => {
   )
 
   const shouldBlur = i => {
+
     if (numberOfCards < 4) return false
-    const endingIndex = (activeItemIndex + numberOfCards) % features.length
-    let startingIndex = endingIndex + numberOfCards - 1
-    if (startingIndex >= features.length) {
-      startingIndex = ((endingIndex + numberOfCards) % features.length) - 1
+
+    if (numberOfCards == 6) {
+      if (i === activeItemIndex || i == activeItemIndex % features.length) return true
+      if (i === (activeItemIndex + 5) || i == (activeItemIndex + 5) % features.length) return true
     }
-    if (i === endingIndex) return true
-    if (i === startingIndex) return true
+
+    if (numberOfCards == 4) {
+      const endingIndex = (activeItemIndex + numberOfCards) % features.length
+      let startingIndex = endingIndex + numberOfCards - 1
+      if (startingIndex >= features.length) {
+        startingIndex = ((endingIndex + numberOfCards) % features.length) - 1
+      }
+      if (i === endingIndex) return true
+      if (i === startingIndex) return true
+    }
+
   }
 
   // Prevent the background from scrolling if modal is ope
@@ -179,6 +189,12 @@ export default () => {
   const width = useWindowWidth()
   const CARD_WIDTH = 310
   let numberOfCards = Math.floor(width / CARD_WIDTH)
-  if (numberOfCards > 4) numberOfCards = 4
+
+    if (width > 1900) {
+      if (numberOfCards > 6) numberOfCards = 6
+    } else {
+      if (numberOfCards > 4) numberOfCards = 4
+    }
+
   return <FeatureCards numberOfCards={numberOfCards} />
 }

--- a/src/components/news-articles/NewsArticles.js
+++ b/src/components/news-articles/NewsArticles.js
@@ -21,12 +21,12 @@ export const NewsArticles = React.memo(({ numberOfCards }) => {
 
     if (numberOfCards < 4) return false
 
-    if (numberOfCards == 6) {
-      if (i === activeItemIndex || i == activeItemIndex % articles.length) return true
-      if (i === (activeItemIndex + 5) || i == (activeItemIndex + 5) % articles.length) return true
+    if (numberOfCards === 6) {
+      if (i === activeItemIndex || i === activeItemIndex % articles.length) return true
+      if (i === (activeItemIndex + 5) || i === (activeItemIndex + 5) % articles.length) return true
     }
 
-    if (numberOfCards == 4) {
+    if (numberOfCards === 4) {
       const endingIndex = (activeItemIndex + numberOfCards) % articles.length
       let startingIndex = endingIndex + 1
       if (startingIndex >= articles.length) {

--- a/src/components/news-articles/NewsArticles.js
+++ b/src/components/news-articles/NewsArticles.js
@@ -18,14 +18,24 @@ export const NewsArticles = React.memo(({ numberOfCards }) => {
   const [activeItemIndex, setActiveItemIndex] = useState(0)
 
   const shouldBlur = i => {
+
     if (numberOfCards < 4) return false
-    const endingIndex = (activeItemIndex + numberOfCards) % articles.length
-    let startingIndex = endingIndex + 1
-    if (startingIndex >= articles.length) {
-      startingIndex = 0
+
+    if (numberOfCards == 6) {
+      if (i === activeItemIndex || i == activeItemIndex % articles.length) return true
+      if (i === (activeItemIndex + 5) || i == (activeItemIndex + 5) % articles.length) return true
     }
-    if (i === endingIndex) return true
-    if (i === startingIndex) return true
+
+    if (numberOfCards == 4) {
+      const endingIndex = (activeItemIndex + numberOfCards) % articles.length
+      let startingIndex = endingIndex + 1
+      if (startingIndex >= articles.length) {
+        startingIndex = 0
+      }
+      if (i === endingIndex) return true
+      if (i === startingIndex) return true
+    }
+
   }
 
   return (
@@ -89,7 +99,11 @@ export default () => {
   const CARD_WIDTH = 310
   let numberOfCards = Math.floor(width / CARD_WIDTH)
 
-  if (numberOfCards > 4) numberOfCards = 4
+  if (width > 1900) {
+    if (numberOfCards > 6) numberOfCards = 6
+  } else {
+    if (numberOfCards > 4) numberOfCards = 4
+  }
 
   return <NewsArticles numberOfCards={numberOfCards} />
 }

--- a/src/components/news-articles/NewsArticles.js
+++ b/src/components/news-articles/NewsArticles.js
@@ -96,10 +96,10 @@ export const NewsArticles = React.memo(({ numberOfCards }) => {
 
 export default () => {
   const width = useWindowWidth()
-  const CARD_WIDTH = 310
+  const CARD_WIDTH = 300
   let numberOfCards = Math.floor(width / CARD_WIDTH)
 
-  if (width > 1900) {
+  if (width > 1800) {
     if (numberOfCards > 6) numberOfCards = 6
   } else {
     if (numberOfCards > 4) numberOfCards = 4

--- a/src/index.css
+++ b/src/index.css
@@ -99,7 +99,7 @@ div:focus {
   filter: invert(0%);
 }
 
-@media screen and (min-width: 1900px) {
+@media screen and (min-width: 1800px) {
 .carousel-wrapper {
   width: 1825px !important;
   margin-left: -325px;

--- a/src/index.css
+++ b/src/index.css
@@ -88,23 +88,22 @@ div:focus {
 }
 
 .list-block-height-container img, #footer-social-icons a, .carousel-button-container img, #desktop-coz-logo img, #mobile-coz-logo img, #chevron-right-transfer, #burger-menu-icon, .expanding-panel-container .explore-button img {
-  filter: invert(100%);
+    filter: invert(100%);
 }
 
 .dark-mode .list-block-height-container img, .dark-mode #footer-social-icons a, .dark-mode .carousel-button-container img, .dark-mode #desktop-coz-logo img, .dark-mode #mobile-coz-logo img, .dark-mode #chevron-right-transfer, .dark-mode #burger-menu-icon, .dark-mode .expanding-panel-container .explore-button img {
-  filter: invert(0%);
+    filter: invert(0%);
 }
 
 @media screen and (min-width: 1800px) {
-.carousel-wrapper {
-  width: 1825px !important;
-  margin-left: -325px;
-  overflow: hidden;
-}
-
-.carousel-item-wrapper {
-  width: 15.7% !important;
-}
+    .carousel-wrapper {
+        width: 1825px !important;
+        margin-left: -325px;
+        overflow: hidden;
+    }
+    .carousel-item-wrapper {
+        width: 15.7% !important;
+    }
 }
 
 @media screen and (-webkit-min-device-pixel-ratio: 0) {

--- a/src/index.css
+++ b/src/index.css
@@ -32,10 +32,6 @@ code {
     monospace;
 }
 
-.hide-card {
-  display: none !important;
-}
-
 :root {
   --primary-color: #ffffff;
   --secondary-color: #f6f6f6;

--- a/src/index.css
+++ b/src/index.css
@@ -32,6 +32,10 @@ code {
     monospace;
 }
 
+.hide-card {
+  display: none !important;
+}
+
 :root {
   --primary-color: #ffffff;
   --secondary-color: #f6f6f6;
@@ -93,6 +97,18 @@ div:focus {
 
 .dark-mode .list-block-height-container img, .dark-mode #footer-social-icons a, .dark-mode .carousel-button-container img, .dark-mode #desktop-coz-logo img, .dark-mode #mobile-coz-logo img, .dark-mode #chevron-right-transfer, .dark-mode #burger-menu-icon, .dark-mode .expanding-panel-container .explore-button img {
   filter: invert(0%);
+}
+
+@media screen and (min-width: 1900px) {
+.carousel-wrapper {
+  width: 1825px !important;
+  margin-left: -325px;
+  overflow: hidden;
+}
+
+.carousel-item-wrapper {
+  width: 15.7% !important;
+}
 }
 
 @media screen and (-webkit-min-device-pixel-ratio: 0) {


### PR DESCRIPTION
Played around with the half cards on large resolutions. Since you're using an infinite loop carousel, there's no easy way to distinguish and hide easily only "all but current/previous one/next one".

So here's a solution where I removed the overflow from the main container, added a custom width for large resolutions, with a different container size with its own overflow:hidden. 

Also had to alter the logic of blurring the cards, since in that case the number of cards was different given the container length size.

Let me know how that looks and if this a viable solution to the "half blurry cards", I thought it looked better overall :)