### PR TITLE
Fix Carousel Overflow Bug

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -118,12 +118,6 @@ div:focus {
   filter: invert(0%);
 }
 
-@media screen and (min-width: 1400px) and (max-width: 1799px) {
-  .carousel-wrapper {
-    overflow-x: visible !important;
-  }
-}
-
 @media screen and (min-width: 1800px) {
   .carousel-wrapper {
     width: 1825px !important;

--- a/src/index.css
+++ b/src/index.css
@@ -125,8 +125,7 @@ div:focus {
 
   .content {
     margin: auto;
-    max-width: 1440px !important ;
-    min-width: 1440px !important;
+    width: 1440px;
   }
 
   #root {

--- a/src/index.css
+++ b/src/index.css
@@ -118,6 +118,22 @@ div:focus {
   filter: invert(0%);
 }
 
+@media screen and (min-width: 1400px) and (max-width: 1799px) {
+  .carousel-wrapper {
+    overflow-x: visible !important;
+  }
+
+  .content {
+    margin: auto;
+    max-width: 1440px !important ;
+    min-width: 1440px !important;
+  }
+
+  #root {
+    overflow-x: hidden;
+  }
+}
+
 @media screen and (min-width: 1800px) {
   .carousel-wrapper {
     width: 1825px !important;


### PR DESCRIPTION
- Removed CSS that was causing overflowed cards to show up in the carousel at 1400px+ width.
- Formatted index.scss

Before:
<img width="1440" alt="Screen Shot 2020-04-23 at 2 50 39 PM" src="https://user-images.githubusercontent.com/16405652/80137814-d932b880-8571-11ea-8919-7041fb221a7a.png">

After:
<img width="1439" alt="Screen Shot 2020-04-23 at 2 50 51 PM" src="https://user-images.githubusercontent.com/16405652/80137830-de900300-8571-11ea-8102-8591c4b0d0d0.png">
